### PR TITLE
Bump nbdefense sdk version to 1.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
-dependencies = [
-    "nbdefense==1.0.3"
-]
+dependencies = ["nbdefense==1.0.4"]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Improves security by bumping underlying numpy version. Release notes: https://github.com/protectai/nbdefense/releases/tag/v1.0.4